### PR TITLE
Implement /v2/auth/register

### DIFF
--- a/rootfs/Gemfile
+++ b/rootfs/Gemfile
@@ -17,12 +17,13 @@ gem 'dry-system'
 gem 'shield'
 gem 'mote'
 gem 'tas'
+gem 'pbkdf2_password_hasher'
 
 # Persistence
-#gem 'rom'
-#gem 'rom-sql'
-#gem 'pg'
-#gem 'sequel_pg'
+gem 'rom'
+gem 'rom-sql'
+gem 'pg'
+gem 'sequel_pg'
 
 gem 'bcrypt'
 
@@ -36,4 +37,5 @@ group :test do
   gem 'database_cleaner'
   gem 'capybara'
   gem 'timecop'
+  gem 'faker'
 end

--- a/rootfs/Gemfile.lock
+++ b/rootfs/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       dry-core (~> 0.4)
       dry-equalizer (~> 0.2)
     dry-inflector (0.1.2)
+    dry-initializer (3.0.1)
     dry-logic (1.0.3)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.2)
@@ -89,7 +90,11 @@ GEM
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
     factis (1.0.1)
+    faker (2.1.2)
+      i18n (>= 0.8)
     gherkin (5.1.0)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     json (2.2.0)
     mini_mime (1.0.2)
@@ -100,6 +105,8 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    pbkdf2_password_hasher (0.2.0)
+    pg (1.1.4)
     public_suffix (3.1.1)
     puma (4.0.1)
       nio4r (~> 2.0)
@@ -110,6 +117,34 @@ GEM
       rack (>= 1.1.0)
     rake (10.5.0)
     regexp_parser (1.6.0)
+    rom (5.1.2)
+      rom-changeset (~> 5.1)
+      rom-core (~> 5.1, >= 5.1.2)
+      rom-repository (~> 5.1)
+    rom-changeset (5.1.2)
+      dry-core (~> 0.4)
+      rom-core (~> 5.1, >= 5.1.2)
+      transproc (~> 1.0, >= 1.1.0)
+    rom-core (5.1.2)
+      concurrent-ruby (~> 1.1)
+      dry-container (~> 0.7)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
+      dry-inflector (~> 0.1)
+      dry-initializer (~> 3.0, >= 3.0.1)
+      dry-struct (~> 1.0)
+      dry-types (~> 1.0)
+      transproc (~> 1.0, >= 1.1.0)
+    rom-repository (5.1.2)
+      dry-core (~> 0.4)
+      dry-initializer (~> 3.0, >= 3.0.1)
+      rom-core (~> 5.1, >= 5.1.2)
+    rom-sql (3.0.1)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
+      dry-types (~> 1.0)
+      rom-core (~> 5.0, >= 5.0.1)
+      sequel (>= 4.49)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -124,6 +159,10 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
     seg (1.2.0)
+    sequel (5.23.0)
+    sequel_pg (1.12.2)
+      pg (>= 0.18.0)
+      sequel (>= 4.38.0)
     shield (2.1.1)
       armor
     simplecov (0.17.0)
@@ -136,6 +175,7 @@ GEM
       seg
     tas (0.0.1)
     timecop (0.9.1)
+    transproc (1.1.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -153,13 +193,19 @@ DEPENDENCIES
   dry-system
   dry-transaction
   factis (~> 1.0)
+  faker
   mote
+  pbkdf2_password_hasher
+  pg
   puma
   rack (>= 2.0)
   rack-test (~> 1.1)
   rack_csrf
   rake (~> 10.0)
+  rom
+  rom-sql
   rspec (~> 3.8)
+  sequel_pg
   shield
   simplecov (~> 0.17)
   syro (~> 3.1)
@@ -167,4 +213,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/rootfs/Rakefile
+++ b/rootfs/Rakefile
@@ -4,3 +4,12 @@ desc "Run Cucumber suite"
 Cucumber::Rake::Task.new
 
 task :default => :cucumber
+
+require 'rom/sql/rake_task'
+
+require_relative 'system/controller/container'
+namespace :db do
+  task :setup do
+    Controller::Container.start :rom
+  end
+end

--- a/rootfs/db/migrate/20190820210856_auth_user.rb
+++ b/rootfs/db/migrate/20190820210856_auth_user.rb
@@ -1,0 +1,20 @@
+ROM::SQL.migration do
+  change do
+    create_table :auth_user do
+      primary_key :id
+
+      column :username, 'character varying(150)', null: false
+      column :email, 'character varying(254)', null: false
+      column :password, 'character varying(128)', null: false
+      column :first_name, 'character varying(30)', null: false
+      column :last_name, 'character varying(30)', null: false
+
+      column :is_superuser, 'boolean', null: false
+      column :is_staff, 'boolean', null: false
+      column :is_active, 'boolean', null: false
+
+      column :date_joined, 'timestamp with time zone', null: false
+      column :last_login, 'timestamp with time zone', null: false
+    end
+  end
+end

--- a/rootfs/db/structure.sql
+++ b/rootfs/db/structure.sql
@@ -1,0 +1,1689 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 11.2
+-- Dumped by pg_dump version 11.2
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: api_app; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_app (
+    uuid uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    id character varying(63),
+    structure text NOT NULL,
+    owner_id integer NOT NULL,
+    procfile_structure text NOT NULL
+);
+
+
+ALTER TABLE public.api_app OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_appsettings; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_appsettings (
+    uuid uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    maintenance boolean,
+    routable boolean,
+    app_id uuid NOT NULL,
+    owner_id integer NOT NULL,
+    whitelist character varying(50)[] NOT NULL,
+    autoscale text NOT NULL,
+    label text NOT NULL
+);
+
+
+ALTER TABLE public.api_appsettings OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_build; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_build (
+    uuid uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    image text NOT NULL,
+    sha character varying(40) NOT NULL,
+    procfile text NOT NULL,
+    dockerfile text NOT NULL,
+    app_id uuid NOT NULL,
+    owner_id integer NOT NULL
+);
+
+
+ALTER TABLE public.api_build OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_certificate; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_certificate (
+    id integer NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    certificate text NOT NULL,
+    key text NOT NULL,
+    common_name text,
+    expires timestamp with time zone NOT NULL,
+    owner_id integer NOT NULL,
+    fingerprint character varying(96) NOT NULL,
+    name character varying(253) NOT NULL,
+    san character varying(253)[],
+    issuer text NOT NULL,
+    starts timestamp with time zone NOT NULL,
+    subject text NOT NULL
+);
+
+
+ALTER TABLE public.api_certificate OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_certificate_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.api_certificate_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.api_certificate_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_certificate_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.api_certificate_id_seq OWNED BY public.api_certificate.id;
+
+
+--
+-- Name: api_config; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_config (
+    uuid uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    "values" text NOT NULL,
+    memory text NOT NULL,
+    cpu text NOT NULL,
+    tags text NOT NULL,
+    app_id uuid NOT NULL,
+    owner_id integer NOT NULL,
+    registry text NOT NULL,
+    healthcheck text NOT NULL,
+    lifecycle_post_start text NOT NULL,
+    lifecycle_pre_stop text NOT NULL,
+    termination_grace_period text NOT NULL
+);
+
+
+ALTER TABLE public.api_config OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_domain; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_domain (
+    id integer NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    domain text NOT NULL,
+    app_id uuid NOT NULL,
+    owner_id integer NOT NULL,
+    certificate_id integer
+);
+
+
+ALTER TABLE public.api_domain OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_domain_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.api_domain_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.api_domain_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_domain_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.api_domain_id_seq OWNED BY public.api_domain.id;
+
+
+--
+-- Name: api_key; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_key (
+    uuid uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    id character varying(128) NOT NULL,
+    public text NOT NULL,
+    fingerprint character varying(128) NOT NULL,
+    owner_id integer NOT NULL
+);
+
+
+ALTER TABLE public.api_key OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_release; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_release (
+    uuid uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    version integer NOT NULL,
+    summary text,
+    app_id uuid NOT NULL,
+    build_id uuid,
+    config_id uuid NOT NULL,
+    owner_id integer NOT NULL,
+    failed boolean NOT NULL,
+    exception text,
+    CONSTRAINT api_release_version_check CHECK ((version >= 0))
+);
+
+
+ALTER TABLE public.api_release OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_service; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_service (
+    id integer NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    procfile_type text NOT NULL,
+    path_pattern text NOT NULL,
+    app_id uuid NOT NULL,
+    owner_id integer NOT NULL
+);
+
+
+ALTER TABLE public.api_service OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_service_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.api_service_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.api_service_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: api_service_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.api_service_id_seq OWNED BY public.api_service.id;
+
+
+--
+-- Name: api_tls; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.api_tls (
+    uuid uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    https_enforced boolean,
+    app_id uuid NOT NULL,
+    owner_id integer NOT NULL
+);
+
+
+ALTER TABLE public.api_tls OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_group; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.auth_group (
+    id integer NOT NULL,
+    name character varying(80) NOT NULL
+);
+
+
+ALTER TABLE public.auth_group OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_group_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.auth_group_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.auth_group_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_group_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.auth_group_id_seq OWNED BY public.auth_group.id;
+
+
+--
+-- Name: auth_group_permissions; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.auth_group_permissions (
+    id integer NOT NULL,
+    group_id integer NOT NULL,
+    permission_id integer NOT NULL
+);
+
+
+ALTER TABLE public.auth_group_permissions OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_group_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.auth_group_permissions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.auth_group_permissions_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_group_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.auth_group_permissions_id_seq OWNED BY public.auth_group_permissions.id;
+
+
+--
+-- Name: auth_permission; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.auth_permission (
+    id integer NOT NULL,
+    name character varying(255) NOT NULL,
+    content_type_id integer NOT NULL,
+    codename character varying(100) NOT NULL
+);
+
+
+ALTER TABLE public.auth_permission OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_permission_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.auth_permission_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.auth_permission_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_permission_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.auth_permission_id_seq OWNED BY public.auth_permission.id;
+
+
+--
+-- Name: auth_user; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.auth_user (
+    id integer NOT NULL,
+    password character varying(128) NOT NULL,
+    last_login timestamp with time zone,
+    is_superuser boolean NOT NULL,
+    username character varying(150) NOT NULL,
+    first_name character varying(30) NOT NULL,
+    last_name character varying(30) NOT NULL,
+    email character varying(254) NOT NULL,
+    is_staff boolean NOT NULL,
+    is_active boolean NOT NULL,
+    date_joined timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE public.auth_user OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_user_groups; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.auth_user_groups (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    group_id integer NOT NULL
+);
+
+
+ALTER TABLE public.auth_user_groups OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_user_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.auth_user_groups_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.auth_user_groups_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_user_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.auth_user_groups_id_seq OWNED BY public.auth_user_groups.id;
+
+
+--
+-- Name: auth_user_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.auth_user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.auth_user_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.auth_user_id_seq OWNED BY public.auth_user.id;
+
+
+--
+-- Name: auth_user_user_permissions; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.auth_user_user_permissions (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    permission_id integer NOT NULL
+);
+
+
+ALTER TABLE public.auth_user_user_permissions OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.auth_user_user_permissions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.auth_user_user_permissions_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: auth_user_user_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.auth_user_user_permissions_id_seq OWNED BY public.auth_user_user_permissions.id;
+
+
+--
+-- Name: authtoken_token; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.authtoken_token (
+    key character varying(40) NOT NULL,
+    created timestamp with time zone NOT NULL,
+    user_id integer NOT NULL
+);
+
+
+ALTER TABLE public.authtoken_token OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: django_content_type; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.django_content_type (
+    id integer NOT NULL,
+    app_label character varying(100) NOT NULL,
+    model character varying(100) NOT NULL
+);
+
+
+ALTER TABLE public.django_content_type OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: django_content_type_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.django_content_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.django_content_type_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: django_content_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.django_content_type_id_seq OWNED BY public.django_content_type.id;
+
+
+--
+-- Name: django_migrations; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.django_migrations (
+    id integer NOT NULL,
+    app character varying(255) NOT NULL,
+    name character varying(255) NOT NULL,
+    applied timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE public.django_migrations OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: django_migrations_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.django_migrations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.django_migrations_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: django_migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.django_migrations_id_seq OWNED BY public.django_migrations.id;
+
+
+--
+-- Name: django_session; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.django_session (
+    session_key character varying(40) NOT NULL,
+    session_data text NOT NULL,
+    expire_date timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE public.django_session OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: guardian_groupobjectpermission; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.guardian_groupobjectpermission (
+    id integer NOT NULL,
+    object_pk character varying(255) NOT NULL,
+    content_type_id integer NOT NULL,
+    group_id integer NOT NULL,
+    permission_id integer NOT NULL
+);
+
+
+ALTER TABLE public.guardian_groupobjectpermission OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: guardian_groupobjectpermission_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.guardian_groupobjectpermission_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.guardian_groupobjectpermission_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: guardian_groupobjectpermission_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.guardian_groupobjectpermission_id_seq OWNED BY public.guardian_groupobjectpermission.id;
+
+
+--
+-- Name: guardian_userobjectpermission; Type: TABLE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE TABLE public.guardian_userobjectpermission (
+    id integer NOT NULL,
+    object_pk character varying(255) NOT NULL,
+    content_type_id integer NOT NULL,
+    permission_id integer NOT NULL,
+    user_id integer NOT NULL
+);
+
+
+ALTER TABLE public.guardian_userobjectpermission OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: guardian_userobjectpermission_id_seq; Type: SEQUENCE; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE SEQUENCE public.guardian_userobjectpermission_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.guardian_userobjectpermission_id_seq OWNER TO "DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D";
+
+--
+-- Name: guardian_userobjectpermission_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER SEQUENCE public.guardian_userobjectpermission_id_seq OWNED BY public.guardian_userobjectpermission.id;
+
+
+--
+-- Name: api_certificate id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_certificate ALTER COLUMN id SET DEFAULT nextval('public.api_certificate_id_seq'::regclass);
+
+
+--
+-- Name: api_domain id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_domain ALTER COLUMN id SET DEFAULT nextval('public.api_domain_id_seq'::regclass);
+
+
+--
+-- Name: api_service id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_service ALTER COLUMN id SET DEFAULT nextval('public.api_service_id_seq'::regclass);
+
+
+--
+-- Name: auth_group id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group ALTER COLUMN id SET DEFAULT nextval('public.auth_group_id_seq'::regclass);
+
+
+--
+-- Name: auth_group_permissions id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group_permissions ALTER COLUMN id SET DEFAULT nextval('public.auth_group_permissions_id_seq'::regclass);
+
+
+--
+-- Name: auth_permission id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_permission ALTER COLUMN id SET DEFAULT nextval('public.auth_permission_id_seq'::regclass);
+
+
+--
+-- Name: auth_user id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user ALTER COLUMN id SET DEFAULT nextval('public.auth_user_id_seq'::regclass);
+
+
+--
+-- Name: auth_user_groups id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_groups ALTER COLUMN id SET DEFAULT nextval('public.auth_user_groups_id_seq'::regclass);
+
+
+--
+-- Name: auth_user_user_permissions id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_user_permissions ALTER COLUMN id SET DEFAULT nextval('public.auth_user_user_permissions_id_seq'::regclass);
+
+
+--
+-- Name: django_content_type id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.django_content_type ALTER COLUMN id SET DEFAULT nextval('public.django_content_type_id_seq'::regclass);
+
+
+--
+-- Name: django_migrations id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.django_migrations ALTER COLUMN id SET DEFAULT nextval('public.django_migrations_id_seq'::regclass);
+
+
+--
+-- Name: guardian_groupobjectpermission id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_groupobjectpermission ALTER COLUMN id SET DEFAULT nextval('public.guardian_groupobjectpermission_id_seq'::regclass);
+
+
+--
+-- Name: guardian_userobjectpermission id; Type: DEFAULT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_userobjectpermission ALTER COLUMN id SET DEFAULT nextval('public.guardian_userobjectpermission_id_seq'::regclass);
+
+
+--
+-- Name: api_app api_app_id_key; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_app
+    ADD CONSTRAINT api_app_id_key UNIQUE (id);
+
+
+--
+-- Name: api_app api_app_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_app
+    ADD CONSTRAINT api_app_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: api_appsettings api_appsettings_app_id_uuid_270b9c16_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_appsettings
+    ADD CONSTRAINT api_appsettings_app_id_uuid_270b9c16_uniq UNIQUE (app_id, uuid);
+
+
+--
+-- Name: api_appsettings api_appsettings_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_appsettings
+    ADD CONSTRAINT api_appsettings_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: api_build api_build_app_id_uuid_0a142ee9_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_build
+    ADD CONSTRAINT api_build_app_id_uuid_0a142ee9_uniq UNIQUE (app_id, uuid);
+
+
+--
+-- Name: api_build api_build_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_build
+    ADD CONSTRAINT api_build_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: api_certificate api_certificate_name_key; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_certificate
+    ADD CONSTRAINT api_certificate_name_key UNIQUE (name);
+
+
+--
+-- Name: api_certificate api_certificate_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_certificate
+    ADD CONSTRAINT api_certificate_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: api_config api_config_app_id_uuid_f49723a8_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_config
+    ADD CONSTRAINT api_config_app_id_uuid_f49723a8_uniq UNIQUE (app_id, uuid);
+
+
+--
+-- Name: api_config api_config_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_config
+    ADD CONSTRAINT api_config_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: api_domain api_domain_domain_key; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_domain
+    ADD CONSTRAINT api_domain_domain_key UNIQUE (domain);
+
+
+--
+-- Name: api_domain api_domain_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_domain
+    ADD CONSTRAINT api_domain_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: api_key api_key_id_095e8b3a_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_key
+    ADD CONSTRAINT api_key_id_095e8b3a_uniq UNIQUE (id);
+
+
+--
+-- Name: api_key api_key_owner_id_fingerprint_17cba2c3_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_key
+    ADD CONSTRAINT api_key_owner_id_fingerprint_17cba2c3_uniq UNIQUE (owner_id, fingerprint);
+
+
+--
+-- Name: api_key api_key_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_key
+    ADD CONSTRAINT api_key_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: api_key api_key_public_key; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_key
+    ADD CONSTRAINT api_key_public_key UNIQUE (public);
+
+
+--
+-- Name: api_release api_release_app_id_version_e492eaee_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_release
+    ADD CONSTRAINT api_release_app_id_version_e492eaee_uniq UNIQUE (app_id, version);
+
+
+--
+-- Name: api_release api_release_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_release
+    ADD CONSTRAINT api_release_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: api_service api_service_app_id_procfile_type_75ffa225_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_service
+    ADD CONSTRAINT api_service_app_id_procfile_type_75ffa225_uniq UNIQUE (app_id, procfile_type);
+
+
+--
+-- Name: api_service api_service_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_service
+    ADD CONSTRAINT api_service_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: api_tls api_tls_app_id_uuid_ba010077_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_tls
+    ADD CONSTRAINT api_tls_app_id_uuid_ba010077_uniq UNIQUE (app_id, uuid);
+
+
+--
+-- Name: api_tls api_tls_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_tls
+    ADD CONSTRAINT api_tls_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: auth_group auth_group_name_key; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group
+    ADD CONSTRAINT auth_group_name_key UNIQUE (name);
+
+
+--
+-- Name: auth_group_permissions auth_group_permissions_group_id_permission_id_0cd325b0_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group_permissions
+    ADD CONSTRAINT auth_group_permissions_group_id_permission_id_0cd325b0_uniq UNIQUE (group_id, permission_id);
+
+
+--
+-- Name: auth_group_permissions auth_group_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group_permissions
+    ADD CONSTRAINT auth_group_permissions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_group auth_group_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group
+    ADD CONSTRAINT auth_group_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_permission auth_permission_content_type_id_codename_01ab375a_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_permission
+    ADD CONSTRAINT auth_permission_content_type_id_codename_01ab375a_uniq UNIQUE (content_type_id, codename);
+
+
+--
+-- Name: auth_permission auth_permission_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_permission
+    ADD CONSTRAINT auth_permission_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_user_groups auth_user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_groups
+    ADD CONSTRAINT auth_user_groups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_user_groups auth_user_groups_user_id_group_id_94350c0c_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_groups
+    ADD CONSTRAINT auth_user_groups_user_id_group_id_94350c0c_uniq UNIQUE (user_id, group_id);
+
+
+--
+-- Name: auth_user auth_user_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user
+    ADD CONSTRAINT auth_user_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_user_user_permissions auth_user_user_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_user_permissions
+    ADD CONSTRAINT auth_user_user_permissions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: auth_user_user_permissions auth_user_user_permissions_user_id_permission_id_14a6b632_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_user_permissions
+    ADD CONSTRAINT auth_user_user_permissions_user_id_permission_id_14a6b632_uniq UNIQUE (user_id, permission_id);
+
+
+--
+-- Name: auth_user auth_user_username_key; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user
+    ADD CONSTRAINT auth_user_username_key UNIQUE (username);
+
+
+--
+-- Name: authtoken_token authtoken_token_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.authtoken_token
+    ADD CONSTRAINT authtoken_token_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: authtoken_token authtoken_token_user_id_key; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.authtoken_token
+    ADD CONSTRAINT authtoken_token_user_id_key UNIQUE (user_id);
+
+
+--
+-- Name: django_content_type django_content_type_app_label_model_76bd3d3b_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.django_content_type
+    ADD CONSTRAINT django_content_type_app_label_model_76bd3d3b_uniq UNIQUE (app_label, model);
+
+
+--
+-- Name: django_content_type django_content_type_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.django_content_type
+    ADD CONSTRAINT django_content_type_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: django_migrations django_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.django_migrations
+    ADD CONSTRAINT django_migrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: django_session django_session_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.django_session
+    ADD CONSTRAINT django_session_pkey PRIMARY KEY (session_key);
+
+
+--
+-- Name: guardian_groupobjectpermission guardian_groupobjectperm_group_id_permission_id_o_3f189f7c_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_groupobjectpermission
+    ADD CONSTRAINT guardian_groupobjectperm_group_id_permission_id_o_3f189f7c_uniq UNIQUE (group_id, permission_id, object_pk);
+
+
+--
+-- Name: guardian_groupobjectpermission guardian_groupobjectpermission_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_groupobjectpermission
+    ADD CONSTRAINT guardian_groupobjectpermission_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: guardian_userobjectpermission guardian_userobjectpermi_user_id_permission_id_ob_b0b3d2fc_uniq; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_userobjectpermission
+    ADD CONSTRAINT guardian_userobjectpermi_user_id_permission_id_ob_b0b3d2fc_uniq UNIQUE (user_id, permission_id, object_pk);
+
+
+--
+-- Name: guardian_userobjectpermission guardian_userobjectpermission_pkey; Type: CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_userobjectpermission
+    ADD CONSTRAINT guardian_userobjectpermission_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: api_app_id_fc451c07_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_app_id_fc451c07_like ON public.api_app USING btree (id varchar_pattern_ops);
+
+
+--
+-- Name: api_app_owner_id_cbebbc18; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_app_owner_id_cbebbc18 ON public.api_app USING btree (owner_id);
+
+
+--
+-- Name: api_appsettings_app_id_7efe8542; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_appsettings_app_id_7efe8542 ON public.api_appsettings USING btree (app_id);
+
+
+--
+-- Name: api_appsettings_owner_id_83ed19f7; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_appsettings_owner_id_83ed19f7 ON public.api_appsettings USING btree (owner_id);
+
+
+--
+-- Name: api_build_app_id_fe641a7d; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_build_app_id_fe641a7d ON public.api_build USING btree (app_id);
+
+
+--
+-- Name: api_build_owner_id_1539e8f2; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_build_owner_id_1539e8f2 ON public.api_build USING btree (owner_id);
+
+
+--
+-- Name: api_certificate_name_e6edbec5_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_certificate_name_e6edbec5_like ON public.api_certificate USING btree (name varchar_pattern_ops);
+
+
+--
+-- Name: api_certificate_owner_id_42adf0cd; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_certificate_owner_id_42adf0cd ON public.api_certificate USING btree (owner_id);
+
+
+--
+-- Name: api_config_app_id_8632bf0d; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_config_app_id_8632bf0d ON public.api_config USING btree (app_id);
+
+
+--
+-- Name: api_config_owner_id_15fcfd4d; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_config_owner_id_15fcfd4d ON public.api_config USING btree (owner_id);
+
+
+--
+-- Name: api_domain_app_id_6acdbe77; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_domain_app_id_6acdbe77 ON public.api_domain USING btree (app_id);
+
+
+--
+-- Name: api_domain_certificate_id_24fc6e9f; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_domain_certificate_id_24fc6e9f ON public.api_domain USING btree (certificate_id);
+
+
+--
+-- Name: api_domain_domain_cf8d9ba9_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_domain_domain_cf8d9ba9_like ON public.api_domain USING btree (domain text_pattern_ops);
+
+
+--
+-- Name: api_domain_owner_id_4c2843c9; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_domain_owner_id_4c2843c9 ON public.api_domain USING btree (owner_id);
+
+
+--
+-- Name: api_key_id_095e8b3a_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_key_id_095e8b3a_like ON public.api_key USING btree (id varchar_pattern_ops);
+
+
+--
+-- Name: api_key_owner_id_e9b7dba6; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_key_owner_id_e9b7dba6 ON public.api_key USING btree (owner_id);
+
+
+--
+-- Name: api_key_public_52103b8a_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_key_public_52103b8a_like ON public.api_key USING btree (public text_pattern_ops);
+
+
+--
+-- Name: api_release_app_id_bd26593f; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_release_app_id_bd26593f ON public.api_release USING btree (app_id);
+
+
+--
+-- Name: api_release_build_id_956f3946; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_release_build_id_956f3946 ON public.api_release USING btree (build_id);
+
+
+--
+-- Name: api_release_config_id_23c173cb; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_release_config_id_23c173cb ON public.api_release USING btree (config_id);
+
+
+--
+-- Name: api_release_owner_id_e8bd2e47; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_release_owner_id_e8bd2e47 ON public.api_release USING btree (owner_id);
+
+
+--
+-- Name: api_service_app_id_04940f79; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_service_app_id_04940f79 ON public.api_service USING btree (app_id);
+
+
+--
+-- Name: api_service_owner_id_ac19479b; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_service_owner_id_ac19479b ON public.api_service USING btree (owner_id);
+
+
+--
+-- Name: api_tls_app_id_a03b23ed; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_tls_app_id_a03b23ed ON public.api_tls USING btree (app_id);
+
+
+--
+-- Name: api_tls_owner_id_278d6863; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX api_tls_owner_id_278d6863 ON public.api_tls USING btree (owner_id);
+
+
+--
+-- Name: auth_group_name_a6ea08ec_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_group_name_a6ea08ec_like ON public.auth_group USING btree (name varchar_pattern_ops);
+
+
+--
+-- Name: auth_group_permissions_group_id_b120cbf9; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_group_permissions_group_id_b120cbf9 ON public.auth_group_permissions USING btree (group_id);
+
+
+--
+-- Name: auth_group_permissions_permission_id_84c5c92e; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_group_permissions_permission_id_84c5c92e ON public.auth_group_permissions USING btree (permission_id);
+
+
+--
+-- Name: auth_permission_content_type_id_2f476e4b; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_permission_content_type_id_2f476e4b ON public.auth_permission USING btree (content_type_id);
+
+
+--
+-- Name: auth_user_groups_group_id_97559544; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_user_groups_group_id_97559544 ON public.auth_user_groups USING btree (group_id);
+
+
+--
+-- Name: auth_user_groups_user_id_6a12ed8b; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_user_groups_user_id_6a12ed8b ON public.auth_user_groups USING btree (user_id);
+
+
+--
+-- Name: auth_user_user_permissions_permission_id_1fbb5f2c; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_user_user_permissions_permission_id_1fbb5f2c ON public.auth_user_user_permissions USING btree (permission_id);
+
+
+--
+-- Name: auth_user_user_permissions_user_id_a95ead1b; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_user_user_permissions_user_id_a95ead1b ON public.auth_user_user_permissions USING btree (user_id);
+
+
+--
+-- Name: auth_user_username_6821ab7c_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX auth_user_username_6821ab7c_like ON public.auth_user USING btree (username varchar_pattern_ops);
+
+
+--
+-- Name: authtoken_token_key_10f0b77e_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX authtoken_token_key_10f0b77e_like ON public.authtoken_token USING btree (key varchar_pattern_ops);
+
+
+--
+-- Name: django_session_expire_date_a5c62663; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX django_session_expire_date_a5c62663 ON public.django_session USING btree (expire_date);
+
+
+--
+-- Name: django_session_session_key_c0390e0f_like; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX django_session_session_key_c0390e0f_like ON public.django_session USING btree (session_key varchar_pattern_ops);
+
+
+--
+-- Name: guardian_groupobjectpermission_content_type_id_7ade36b8; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX guardian_groupobjectpermission_content_type_id_7ade36b8 ON public.guardian_groupobjectpermission USING btree (content_type_id);
+
+
+--
+-- Name: guardian_groupobjectpermission_group_id_4bbbfb62; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX guardian_groupobjectpermission_group_id_4bbbfb62 ON public.guardian_groupobjectpermission USING btree (group_id);
+
+
+--
+-- Name: guardian_groupobjectpermission_permission_id_36572738; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX guardian_groupobjectpermission_permission_id_36572738 ON public.guardian_groupobjectpermission USING btree (permission_id);
+
+
+--
+-- Name: guardian_userobjectpermission_content_type_id_2e892405; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX guardian_userobjectpermission_content_type_id_2e892405 ON public.guardian_userobjectpermission USING btree (content_type_id);
+
+
+--
+-- Name: guardian_userobjectpermission_permission_id_71807bfc; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX guardian_userobjectpermission_permission_id_71807bfc ON public.guardian_userobjectpermission USING btree (permission_id);
+
+
+--
+-- Name: guardian_userobjectpermission_user_id_d5c1e964; Type: INDEX; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+CREATE INDEX guardian_userobjectpermission_user_id_d5c1e964 ON public.guardian_userobjectpermission USING btree (user_id);
+
+
+--
+-- Name: api_app api_app_owner_id_cbebbc18_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_app
+    ADD CONSTRAINT api_app_owner_id_cbebbc18_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_appsettings api_appsettings_app_id_7efe8542_fk_api_app_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_appsettings
+    ADD CONSTRAINT api_appsettings_app_id_7efe8542_fk_api_app_uuid FOREIGN KEY (app_id) REFERENCES public.api_app(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_appsettings api_appsettings_owner_id_83ed19f7_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_appsettings
+    ADD CONSTRAINT api_appsettings_owner_id_83ed19f7_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_build api_build_app_id_fe641a7d_fk_api_app_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_build
+    ADD CONSTRAINT api_build_app_id_fe641a7d_fk_api_app_uuid FOREIGN KEY (app_id) REFERENCES public.api_app(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_build api_build_owner_id_1539e8f2_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_build
+    ADD CONSTRAINT api_build_owner_id_1539e8f2_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_certificate api_certificate_owner_id_42adf0cd_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_certificate
+    ADD CONSTRAINT api_certificate_owner_id_42adf0cd_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_config api_config_app_id_8632bf0d_fk_api_app_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_config
+    ADD CONSTRAINT api_config_app_id_8632bf0d_fk_api_app_uuid FOREIGN KEY (app_id) REFERENCES public.api_app(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_config api_config_owner_id_15fcfd4d_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_config
+    ADD CONSTRAINT api_config_owner_id_15fcfd4d_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_domain api_domain_app_id_6acdbe77_fk_api_app_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_domain
+    ADD CONSTRAINT api_domain_app_id_6acdbe77_fk_api_app_uuid FOREIGN KEY (app_id) REFERENCES public.api_app(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_domain api_domain_certificate_id_24fc6e9f_fk_api_certificate_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_domain
+    ADD CONSTRAINT api_domain_certificate_id_24fc6e9f_fk_api_certificate_id FOREIGN KEY (certificate_id) REFERENCES public.api_certificate(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_domain api_domain_owner_id_4c2843c9_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_domain
+    ADD CONSTRAINT api_domain_owner_id_4c2843c9_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_key api_key_owner_id_e9b7dba6_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_key
+    ADD CONSTRAINT api_key_owner_id_e9b7dba6_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_release api_release_app_id_bd26593f_fk_api_app_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_release
+    ADD CONSTRAINT api_release_app_id_bd26593f_fk_api_app_uuid FOREIGN KEY (app_id) REFERENCES public.api_app(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_release api_release_build_id_956f3946_fk_api_build_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_release
+    ADD CONSTRAINT api_release_build_id_956f3946_fk_api_build_uuid FOREIGN KEY (build_id) REFERENCES public.api_build(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_release api_release_config_id_23c173cb_fk_api_config_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_release
+    ADD CONSTRAINT api_release_config_id_23c173cb_fk_api_config_uuid FOREIGN KEY (config_id) REFERENCES public.api_config(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_release api_release_owner_id_e8bd2e47_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_release
+    ADD CONSTRAINT api_release_owner_id_e8bd2e47_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_service api_service_app_id_04940f79_fk_api_app_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_service
+    ADD CONSTRAINT api_service_app_id_04940f79_fk_api_app_uuid FOREIGN KEY (app_id) REFERENCES public.api_app(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_service api_service_owner_id_ac19479b_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_service
+    ADD CONSTRAINT api_service_owner_id_ac19479b_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_tls api_tls_app_id_a03b23ed_fk_api_app_uuid; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_tls
+    ADD CONSTRAINT api_tls_app_id_a03b23ed_fk_api_app_uuid FOREIGN KEY (app_id) REFERENCES public.api_app(uuid) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: api_tls api_tls_owner_id_278d6863_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.api_tls
+    ADD CONSTRAINT api_tls_owner_id_278d6863_fk_auth_user_id FOREIGN KEY (owner_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: auth_group_permissions auth_group_permissio_permission_id_84c5c92e_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group_permissions
+    ADD CONSTRAINT auth_group_permissio_permission_id_84c5c92e_fk_auth_perm FOREIGN KEY (permission_id) REFERENCES public.auth_permission(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: auth_group_permissions auth_group_permissions_group_id_b120cbf9_fk_auth_group_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_group_permissions
+    ADD CONSTRAINT auth_group_permissions_group_id_b120cbf9_fk_auth_group_id FOREIGN KEY (group_id) REFERENCES public.auth_group(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: auth_permission auth_permission_content_type_id_2f476e4b_fk_django_co; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_permission
+    ADD CONSTRAINT auth_permission_content_type_id_2f476e4b_fk_django_co FOREIGN KEY (content_type_id) REFERENCES public.django_content_type(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: auth_user_groups auth_user_groups_group_id_97559544_fk_auth_group_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_groups
+    ADD CONSTRAINT auth_user_groups_group_id_97559544_fk_auth_group_id FOREIGN KEY (group_id) REFERENCES public.auth_group(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: auth_user_groups auth_user_groups_user_id_6a12ed8b_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_groups
+    ADD CONSTRAINT auth_user_groups_user_id_6a12ed8b_fk_auth_user_id FOREIGN KEY (user_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: auth_user_user_permissions auth_user_user_permi_permission_id_1fbb5f2c_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_user_permissions
+    ADD CONSTRAINT auth_user_user_permi_permission_id_1fbb5f2c_fk_auth_perm FOREIGN KEY (permission_id) REFERENCES public.auth_permission(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: auth_user_user_permissions auth_user_user_permissions_user_id_a95ead1b_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.auth_user_user_permissions
+    ADD CONSTRAINT auth_user_user_permissions_user_id_a95ead1b_fk_auth_user_id FOREIGN KEY (user_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: authtoken_token authtoken_token_user_id_35299eff_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.authtoken_token
+    ADD CONSTRAINT authtoken_token_user_id_35299eff_fk_auth_user_id FOREIGN KEY (user_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: guardian_groupobjectpermission guardian_groupobject_content_type_id_7ade36b8_fk_django_co; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_groupobjectpermission
+    ADD CONSTRAINT guardian_groupobject_content_type_id_7ade36b8_fk_django_co FOREIGN KEY (content_type_id) REFERENCES public.django_content_type(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: guardian_groupobjectpermission guardian_groupobject_group_id_4bbbfb62_fk_auth_grou; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_groupobjectpermission
+    ADD CONSTRAINT guardian_groupobject_group_id_4bbbfb62_fk_auth_grou FOREIGN KEY (group_id) REFERENCES public.auth_group(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: guardian_groupobjectpermission guardian_groupobject_permission_id_36572738_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_groupobjectpermission
+    ADD CONSTRAINT guardian_groupobject_permission_id_36572738_fk_auth_perm FOREIGN KEY (permission_id) REFERENCES public.auth_permission(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: guardian_userobjectpermission guardian_userobjectp_content_type_id_2e892405_fk_django_co; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_userobjectpermission
+    ADD CONSTRAINT guardian_userobjectp_content_type_id_2e892405_fk_django_co FOREIGN KEY (content_type_id) REFERENCES public.django_content_type(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: guardian_userobjectpermission guardian_userobjectp_permission_id_71807bfc_fk_auth_perm; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_userobjectpermission
+    ADD CONSTRAINT guardian_userobjectp_permission_id_71807bfc_fk_auth_perm FOREIGN KEY (permission_id) REFERENCES public.auth_permission(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Name: guardian_userobjectpermission guardian_userobjectpermission_user_id_d5c1e964_fk_auth_user_id; Type: FK CONSTRAINT; Schema: public; Owner: DfKQL1pP5QFD0JOtrwNf3Q2WA7FkHR3D
+--
+
+ALTER TABLE ONLY public.guardian_userobjectpermission
+    ADD CONSTRAINT guardian_userobjectpermission_user_id_d5c1e964_fk_auth_user_id FOREIGN KEY (user_id) REFERENCES public.auth_user(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/rootfs/docker-compose.yml
+++ b/rootfs/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@postgres/controller
+    command: bundle exec rake spec
+    volumes:
+      - .:/app
+    links:
+      - postgres
+
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=controller

--- a/rootfs/docs/v2/auth/register/registering_a_user.md
+++ b/rootfs/docs/v2/auth/register/registering_a_user.md
@@ -1,0 +1,321 @@
+# Registering A User #
+
+Depending on controller configuration, one may be able to self-register an account in the cluster. This is done by `POST`ing data to the `/v2/auth/register` endpoint.
+
+## URI ##
+
+`/v2/auth/register`
+
+## Method(s) ##
+
+`POST`
+
+## Authentication ##
+
+If registration is disabled beyond the initial admin user, authentication (and admin privileges) are required.
+
+If registration is disabled beyond the initial admin user and there is not yet an admin user, authentication is not required.
+
+If registration is not limited to the initial admin user, authentication is not required.
+
+## Data Params ##
+
+```json
+{
+  "username" : "me",
+  "password" : "supersecret",
+  "email" : "me@example.com",
+  "first_name" : "Example",
+  "last_name" : "User"
+}
+```
+
+### Required Attributes ###
+
+* `username` ***String***
+* `email` ***String***
+* `password` ***String***
+
+### Optional Attributes ###
+
+* `first_name` ***String***
+* `last_name` ***String***
+
+### Notes ###
+
+* The data types for all fields are strict.
+* Whitespace is removed from the beginning and end of all attributes before any further processing.
+* Usernames may consist of letters, numbers, and these non-alphanumeric characters: `@.+-_`
+* Usernames may not be blank (ie `""`) after whitespace trimming.
+* Usernames are case-sensitive.
+* Usernames must be unique.
+* Passwords may not be blank (ie `""`) after whitespace trimming.
+* Email must be in the form of a valid email address.
+
+## Success Response ##
+
+A successful response indicates that the user in question was created successfully and returns a representation of that user in the cluster.
+
+### Code ###
+
+`201`
+
+### Content Type ###
+
+`application/json`
+
+### Content ###
+
+```json
+{
+  "email" : "me@example.com",
+  "username" : "me",
+  "first_name" : "me",
+  "last_name" : "example",
+  "is_superuser" : false,
+  "is_staff" : false,
+  "groups" : [],
+  "user_permissions" : [],
+  "last_login" : "a timestamp",
+  "date_joined" : "a timestamp",
+  "is_active" : true
+}
+```
+
+## Error Responses ##
+
+The error scenarios for this endpoint depend somewhat on the controller configuration, but there are also a few data validation errors that may occur.
+
+### Registration Disabled ###
+
+When the controller is configured to not allow registration beyond the initial admin user, unauthenticated requests `/v2/auth/register` fail due to lacking authentication credentials.
+
+#### Code ####
+
+`403`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"detail":"Authentication credentials were not provided."}
+```
+
+### Missing Username ###
+
+If a username is not provided in the data payload for the request, the request fails and an error regarding the missing username is presented.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"username":["This field is required."]}
+```
+
+### Empty Username ###
+
+If an empty string is provided as the username in the data payload for the request, the request fails and an error regarding the blank username is presented.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"username":["This field may not be blank."]}
+```
+
+### Invalid Username ###
+
+A username may contain only alphanumeric characters and the following non-alphanumeric characters: `@.+-_`
+
+If a username is provided with characters not in that set, the request fails with a message about the username format.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"username":["Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters."]}
+```
+
+### Repeated Username ###
+
+Usernames must be unique. If a user already exists, and that user's username is passed in, the request fails with an error regarding username uniqueness.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"username":["A user with that username already exists."]}
+```
+
+### Non-string Username ###
+
+Usernames must be strings. If a non-string username is passed in, the request fails with an error regarding username type.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"username":["This field must be a string."]}
+```
+
+### Missing Password ###
+
+If a password is not provided in the data payload for the request, the request fails and an error regarding the missing password is presented.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"password":["This field is required."]}
+```
+
+### Empty Password ###
+
+If an empty string is provided as the password in the data payload for the request, the request fails and an error regarding the blank password is presented.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"password":["This field may not be blank."]}
+```
+
+### Non-string Password ###
+
+Passwords must be strings. If a non-string password is passed in, the request fails with an error regarding password type.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"password":["This field must be a string."]}
+```
+
+### Missing Email ###
+
+If an email is not provided in the data payload for the request, the request fails and an error regarding the missing email is presented.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"email":["This field is required."]}
+```
+
+### Invalid Email ###
+
+The email field must include a properly-formatted email address.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"email":["Enter a valid email address."]}
+```
+
+### Non-string Email ###
+
+Emails must be strings. If a non-string email is passed in, the request fails with an error regarding email type.
+
+#### Code ####
+
+`400`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"email":["This field must be a string."]}
+```
+
+## Sample Calls ##
+
+### Unauthenticated ###
+
+```
+curl -H "Content-Type: application/json" -X POST -d '{"username":"me","password":"supersecret","email":"me@example.com"}
+http://example.com/v2/auth/register
+```
+
+### Authenticated ###
+
+```
+curl -H 'Authorization: token a1b2c3d4e5f6' -H "Content-Type: application/json" -X POST -d '{"username":"me","password":"supersecret","email":"me@example.com"}
+http://example.com/v2/auth/register
+```

--- a/rootfs/docs/v2/auth/register/registering_a_user.md
+++ b/rootfs/docs/v2/auth/register/registering_a_user.md
@@ -104,6 +104,25 @@ When the controller is configured to not allow registration beyond the initial a
 {"detail":"Authentication credentials were not provided."}
 ```
 
+## Non-Admin User Attempts To Create A User ##
+
+Whether registration is opened or closed, if a non-admin attempts to register another user while authenticated, the request fails with a message regarding lacking permissions.
+
+#### Code ####
+
+`403`
+
+#### Content Type ####
+
+`application/json`
+
+#### Content ####
+
+```json
+{"detail":"You do not have permission to perform this action."}
+```
+
+
 ### Missing Username ###
 
 If a username is not provided in the data payload for the request, the request fails and an error regarding the missing username is presented.

--- a/rootfs/features/healthz/getting_controller_health.feature
+++ b/rootfs/features/healthz/getting_controller_health.feature
@@ -9,19 +9,16 @@ Feature: Getting Controller Health
     When I perform a GET request for /healthz
     Then the response status is 200
     And the HTML body in the response is "OK"
-    And the response includes the magic DEIS headers
 
   Scenario: Inquiring via HEAD
     When I perform a HEAD request for /healthz
     Then the response status is 200
     And the HTML body in the response is "OK"
-    And the response includes the magic DEIS headers
 
     @failure
   Scenario Outline: Any other HTTP verb is disallowed
     When I perform a <HTTP Verb> request for /healthz
     Then the response status is 405
-    But the response includes the magic DEIS headers
 
     Examples:
       | HTTP Verb |

--- a/rootfs/features/readiness/getting_controller_readiness.feature
+++ b/rootfs/features/readiness/getting_controller_readiness.feature
@@ -9,19 +9,16 @@ Feature: Getting Controller Readiness
     When I perform a GET request for /readiness
     Then the response status is 200
     And the HTML body in the response is "OK"
-    And the response includes the magic DEIS headers
 
   Scenario: Inquiring via HEAD
     When I perform a HEAD request for /readiness
     Then the response status is 200
     And the HTML body in the response is "OK"
-    And the response includes the magic DEIS headers
 
     @failure
   Scenario Outline: Any other HTTP verb is disallowed
     When I perform a <HTTP Verb> request for /readiness
     Then the response status is 405
-    But the response includes the magic DEIS headers
 
     Examples:
       | HTTP Verb |

--- a/rootfs/features/step_definitions/authentication_steps.rb
+++ b/rootfs/features/step_definitions/authentication_steps.rb
@@ -1,11 +1,21 @@
-Given 'I have no authentication information' do
+Given %(I have no authentication information) do
   unset_token
 end
 
-Given 'I have valid authentication information' do
+Given %(I have valid authentication information) do
   set_token('supersekrattoken')
 end
 
-Given 'I have invalid authentication information' do
+Given %(I have invalid authentication information) do
   set_token('totallyunknowntoken')
+end
+
+Given %(I have authentication information for an admin user) do
+  u = create_admin_user
+  t = token_for_user(u)
+  fail "not implemented"
+end
+
+Given %(I have authentication information for a non-admin user) do
+  fail "not implemented"
 end

--- a/rootfs/features/step_definitions/controller_steps.rb
+++ b/rootfs/features/step_definitions/controller_steps.rb
@@ -1,0 +1,7 @@
+Given 'the controller is open for registrations' do
+  true
+end
+
+Given 'the controller is closed for registrations' do
+  true
+end

--- a/rootfs/features/step_definitions/payload_steps.rb
+++ b/rootfs/features/step_definitions/payload_steps.rb
@@ -1,0 +1,19 @@
+Given 'my JSON payload looks like this:' do |payload|
+  set_payload(JSON.load(payload))
+end
+
+Given %r{^my payload (.+) is missing$} do |key|
+  remove_payload_key(key)
+end
+
+Given %r{^my payload (.+) is "([^""]*)"$} do |key, value|
+  update_payload_key(key, value)
+end
+
+Given %r{^my payload (.+) isn't a string} do |key|
+  update_payload_key(key, nil)
+end
+
+Given %(my payload email isn't a valid email) do
+  update_payload_key('email', 'invalidemail@domain')
+end

--- a/rootfs/features/step_definitions/rest_steps.rb
+++ b/rootfs/features/step_definitions/rest_steps.rb
@@ -34,3 +34,19 @@ When %r{^I GET (.+) without authentication$} do |path|
   end
 end
 
+When %r{^I POST my payload to (.+) with authentication$} do |path|
+  with_authentication do
+    with_json_body do
+      set_response(post(path, JSON.dump(payload)))
+    end
+  end
+end
+
+
+When %r{^I POST my payload to (.+) without authentication$} do |path|
+  without_authentication do
+    with_json_body do
+      set_response(post(path, JSON.dump(payload)))
+    end
+  end
+end

--- a/rootfs/features/step_definitions/user_steps.rb
+++ b/rootfs/features/step_definitions/user_steps.rb
@@ -1,0 +1,19 @@
+Given %(there are no users) do
+  clear_users
+end
+
+Given %(there is already an admin user) do
+  create_admin_user(username: "admin")
+end
+
+Given %(there's already a user with the username {string}) do |existing_user|
+  create_user(username: existing_user)
+end
+
+Then %(the {string} user is created) do |username|
+  expect(user_by_username(username)).not_to be_nil
+end
+
+Then %(no user is created) do
+  expect(upstream_user_count).to eql(user_count)
+end

--- a/rootfs/features/support/database_cleaner.rb
+++ b/rootfs/features/support/database_cleaner.rb
@@ -1,12 +1,15 @@
-#begin
-  #require 'database_cleaner'
-  #require 'database_cleaner/cucumber'
+require_relative '../../system/boot'
 
-  #DatabaseCleaner.strategy = :truncation
-#rescue NameError
-  #raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
-#end
+require 'database_cleaner'
 
-#Around do |scenario, block|
-  #DatabaseCleaner.cleaning(&block)
-#end
+conn = Controller::Container['persistence.rom'].gateways[:default].connection
+
+DatabaseCleaner.allow_remote_database_url = true
+DatabaseCleaner[:sequel, connection: conn].strategy = :transaction
+DatabaseCleaner[:sequel, connection: conn].clean_with(:truncation)
+
+Around do |scenario, block|
+  conn = Controller::Container['persistence.rom'].gateways[:default].connection
+
+  DatabaseCleaner[:sequel, connection: conn].cleaning(&block)
+end

--- a/rootfs/features/support/deis.rb
+++ b/rootfs/features/support/deis.rb
@@ -1,0 +1,3 @@
+After do
+  step "the response includes the magic DEIS headers"
+end

--- a/rootfs/features/support/factis.rb
+++ b/rootfs/features/support/factis.rb
@@ -1,1 +1,6 @@
-require 'factis/cucumber'
+require 'factis'
+World(Factis)
+
+Before do
+  clear_all_facts!
+end

--- a/rootfs/features/support/payload_helpers.rb
+++ b/rootfs/features/support/payload_helpers.rb
@@ -1,0 +1,21 @@
+module PayloadHelpers
+  def set_payload(payload)
+    indifferently_memorize_fact(:payload, payload)
+  end
+
+  def update_payload_key(key, value)
+    set_payload(payload.merge({key => value}))
+  end
+
+  def remove_payload_key(key)
+    p = payload
+    p.delete(key)
+    set_payload(p)
+  end
+
+  def payload
+    recall_fact(:payload)
+  end
+end
+
+World(PayloadHelpers)

--- a/rootfs/features/support/request_helpers.rb
+++ b/rootfs/features/support/request_helpers.rb
@@ -1,0 +1,16 @@
+module RequestHelpers
+  def with_json_body(&block)
+    old_content_type = current_session.instance_eval {@headers.delete('Content-Type')}
+
+    header('Content-Type', "application/json")
+
+    block.call
+
+    unless old_content_type.nil?
+      header('Content-Type', old_content_type)
+    end
+  end
+
+end
+
+World(RequestHelpers)

--- a/rootfs/features/support/system.rb
+++ b/rootfs/features/support/system.rb
@@ -1,0 +1,3 @@
+require_relative '../../system/boot'
+
+Controller::Container.finalize!

--- a/rootfs/features/support/timecop.rb
+++ b/rootfs/features/support/timecop.rb
@@ -1,5 +1,9 @@
 require 'timecop'
 
-After('@timeywimey') do
+Before do
+  Timecop.freeze(Time.utc(2019, 8, 16, 0, 8, 9))
+end
+
+After do
   Timecop.return
 end

--- a/rootfs/features/support/token_helpers.rb
+++ b/rootfs/features/support/token_helpers.rb
@@ -1,0 +1,7 @@
+module TokenHelpers
+  def token_for_user(user)
+
+  end
+end
+
+World(TokenHelpers)

--- a/rootfs/features/support/user_helpers.rb
+++ b/rootfs/features/support/user_helpers.rb
@@ -1,0 +1,78 @@
+require 'faker'
+
+module UserHelpers
+  def set_user_count(count)
+    indifferently_memorize_fact(:user_count, count)
+  end
+
+  def user_count
+    recall_fact(:user_count)
+  end
+
+  def users_repo
+    Controller::Container['persistence.repositories.users']
+  end
+
+  def clear_users
+    users_repo.all.each do |user|
+      users_repo.delete(user.id)
+    end
+
+    raise "dafuq" unless users_repo.count == 0
+    set_user_count(0)
+  end
+
+  def user_by_username(username)
+    users_repo.named(username)
+  end
+
+  def create_admin_user(user = {})
+    now = DateTime.now
+
+    set_user_count(user_count + 1)
+
+    users_repo.create(
+      user.merge(
+        {
+          password: Faker::Lorem.characters(number: 12),
+          email: Faker::Internet.email,
+          first_name: '',
+          last_name: '',
+          is_superuser: true,
+          is_staff: true,
+          is_active: true,
+          date_joined: now,
+          last_login: now,
+        }
+      )
+    )
+  end
+
+  def create_user(user = {})
+    now = DateTime.now
+
+    set_user_count(user_count + 1)
+
+    users_repo.create(
+      user.merge(
+        {
+          password: Faker::Lorem.characters(number: 12),
+          email: Faker::Internet.email,
+          first_name: '',
+          last_name: '',
+          is_superuser: false,
+          is_staff: false,
+          is_active: false,
+          date_joined: now,
+          last_login: now,
+        }
+      )
+    )
+  end
+
+  def upstream_user_count
+    users_repo.count
+  end
+end
+
+World(UserHelpers)

--- a/rootfs/features/v2/auth/register/registering_a_user.feature
+++ b/rootfs/features/v2/auth/register/registering_a_user.feature
@@ -1,0 +1,201 @@
+Feature: Registering A User
+  I want to use the controller API, and since most of the actions in the API
+  require authentication information, I want to be able to register as a user.
+
+  Background:
+    Given the controller is open for registrations
+    And I have no authentication information
+    And there are no users
+    And my JSON payload looks like this:
+    """
+    {
+      "username"  : "me",
+      "password"  : "supersecret",
+      "email"     : "me@example.com"
+    }
+    """
+
+  Scenario: Registering the first user
+    When I POST my payload to /v2/auth/register without authentication
+    #Then the "me" user is created
+    Then the response status is 201
+    And the JSON body in the response is as follows:
+    """
+    {
+      "username": "me",
+      "email": "me@example.com",
+      "first_name": "",
+      "last_name": "",
+      "is_active" : true,
+      "is_superuser" : true,
+      "is_staff" : true,
+      "groups" : [],
+      "user_permissions" : [],
+      "date_joined" : "2019-08-16T00:08:09Z",
+      "last_login" : "2019-08-16T00:08:09Z"
+    }
+    """
+
+  Scenario: Unauthenticated registration succeeds with registrations open
+    Given there is already an admin user
+    When I POST my payload to /v2/auth/register without authentication
+    Then the "me" user is created
+    And the response status is 201
+    And the JSON body in the response is as follows:
+    """
+    {
+      "username": "me",
+      "email": "me@example.com",
+      "first_name": "",
+      "last_name": "",
+      "is_active" : true,
+      "is_superuser" : false,
+      "is_staff" : false,
+      "groups" : [],
+      "user_permissions" : [],
+      "date_joined" : "2019-08-16T00:08:09Z",
+      "last_login" : "2019-08-16T00:08:09Z"
+    }
+    """
+
+  Scenario: Admin can create users with closed registration and authentication
+    Given the controller is closed for registrations
+    But I have authentication information for an admin user
+    When I POST my payload to /v2/auth/register without authentication
+    Then the "me" user is created
+    And the response status is 201
+    And the JSON body in the response is as follows:
+    """
+    {
+      "username": "me",
+      "email": "me@example.com",
+      "first_name": "",
+      "last_name": "",
+      "is_active" : true,
+      "is_superuser" : false,
+      "is_staff" : false,
+      "groups" : [],
+      "user_permissions" : [],
+      "date_joined" : "2019-08-16T00:08:09Z",
+      "last_login" : "2019-08-16T00:08:09Z"
+    }
+    """
+
+  Scenario: Usernames are case-sensitive
+    Given there's already a user with the username "Me"
+    When I POST my payload to /v2/auth/register without authentication
+    Then the "me" user is created
+    And the response status is 201
+    And the JSON body in the response is as follows:
+    """
+    {
+      "username": "me",
+      "email": "me@example.com",
+      "first_name": "",
+      "last_name": "",
+      "is_active" : true,
+      "is_superuser" : false,
+      "is_staff" : false,
+      "groups" : [],
+      "user_permissions" : [],
+      "date_joined" : "2019-08-16T00:08:09Z",
+      "last_login" : "2019-08-16T00:08:09Z"
+    }
+    """
+
+    @failure
+  Scenario: Unauthenticated registration fails when registration is closed
+    Given the controller is closed for registrations
+    When I POST my payload to /v2/auth/register without authentication
+    Then no user is created
+    And the response status is 403
+    And the JSON body in the response is as follows:
+    """
+    {
+      "detail" : "Authentication credentials were not provided."
+    }
+    """
+
+    @failure
+  Scenario: Non-admin cannot create other users
+    Given I have authentication information for a non-admin user
+    When I POST my payload to /v2/auth/register with authentication
+    Then no user is created
+    And the response status is 403
+    And the JSON body in the response is as follows:
+    """
+    {
+      "detail" : "You do not have permission to perform this action."
+    }
+    """
+
+    @failure
+  Scenario Outline: Registration fails when username is provided incorrectly
+    Given my payload username <Username Issue>
+    When I POST my payload to /v2/auth/register without authentication
+    Then no user is created
+    And the response status is 400
+    And the JSON body in the response is as follows:
+    """
+    {
+      "username" : ["<Error Detail>"]
+    }
+    """
+
+    Examples:
+      | Username Issue        | Error Detail                  |
+      | is missing            | This field is required.       |
+      | is ""                 | This field may not be blank.  |
+      | is "inval!d"          | Enter a valid username. This value may contain only letters, numbers, and @/./+/-/_ characters. |
+      | isn't a string        | This field must be a string.  |
+
+    @failure
+  Scenario: Registration fails when username is not unique
+    Given there's already a user with the username "me"
+    When I POST my payload to /v2/auth/register without authentication
+    Then no user is created
+    And the response status is 400
+    And the JSON body in the response is as follows:
+    """
+    {
+      "username" : ["A user with that username already exists."]
+    }
+    """
+
+    @failure
+  Scenario Outline: Registration fails when password is provided incorrectly
+    Given my payload password <Password Issue>
+    When I POST my payload to /v2/auth/register without authentication
+    Then no user is created
+    And the response status is 400
+    And the JSON body in the response is as follows:
+    """
+    {
+      "password" : ["<Error Detail>"]
+    }
+    """
+
+    Examples:
+      | Password Issue  | Error Detail                  |
+      | is missing      | This field is required.       |
+      | is ""           | This field may not be blank.  |
+      | isn't a string  | This field must be a string.  |
+
+    @failure
+  Scenario Outline: Registration fails when email is provided incorrectly
+    Given my payload email <Email Issue>
+    When I POST my payload to /v2/auth/register without authentication
+    Then no user is created
+    And the response status is 400
+    And the JSON body in the response is as follows:
+    """
+    {
+      "email" : ["<Error Detail>"]
+    }
+    """
+
+    Examples:
+      | Email Issue         | Error Detail                  |
+      | is missing          | This field is required.       |
+      | isn't a valid email | Enter a valid email address.  |
+      | isn't a string      | This field must be a string.  |

--- a/rootfs/features/v2/checking_token_validity.feature
+++ b/rootfs/features/v2/checking_token_validity.feature
@@ -6,7 +6,6 @@ Feature: Checking Token Validity
     Given I have valid authentication information
     When I GET /v2/ with authentication
     Then the response status is 200
-    And the response includes the magic DEIS headers
     And the JSON body in the response is as follows:
     """
     {}
@@ -16,7 +15,6 @@ Feature: Checking Token Validity
   Scenario: I don't provide a token
     When I GET /v2/ without authentication
     Then the response status is 401
-    And the response includes the magic DEIS headers
     And the JSON body in the response is as follows:
     """
     {
@@ -29,7 +27,6 @@ Feature: Checking Token Validity
     Given I have invalid authentication information
     When I GET /v2/ with authentication
     Then the response status is 401
-    And the response includes the magic DEIS headers
     And the JSON body in the response is as follows:
     """
     {

--- a/rootfs/lib/persistence/relations/users.rb
+++ b/rootfs/lib/persistence/relations/users.rb
@@ -1,0 +1,32 @@
+require 'rom'
+require 'rom-sql'
+
+module Persistence
+  module Relations
+    class Users < ROM::Relation[:sql]
+      schema(:auth_user) do
+        attribute :id, Types::Serial
+        attribute :username, Types::Strict::String
+        attribute :email, Types::Strict::String
+        attribute :password, Types::Strict::String
+        attribute :first_name, Types::Strict::String
+        attribute :last_name, Types::Strict::String
+
+        attribute :is_superuser, Types::Strict::Bool
+        attribute :is_staff, Types::Strict::Bool
+        attribute :is_active, Types::Strict::Bool
+
+        attribute :date_joined, Types::Strict::DateTime
+        attribute :last_login, Types::Strict::DateTime
+      end
+
+      def by_id(id)
+        where(id: id)
+      end
+
+      def by_username(username)
+        where(username: username)
+      end
+    end
+  end
+end

--- a/rootfs/lib/persistence/repositories/users.rb
+++ b/rootfs/lib/persistence/repositories/users.rb
@@ -1,0 +1,30 @@
+require_relative '../../../system/repository'
+
+module Persistence
+  module Repositories
+    class Users < Controller::Repository[:auth_user]
+      commands :create, update: :by_pk, delete: :by_pk
+
+      def [](id)
+        auth_user.by_id(id).one!
+      end
+
+      def named(username)
+        auth_user.where(username: username).to_a
+      end
+
+      def all
+        auth_user.to_a
+      end
+
+      def count
+        auth_user.count
+      end
+
+      def admins
+        auth_user.where(is_superuser: true).to_a
+      end
+
+    end
+  end
+end

--- a/rootfs/lib/types.rb
+++ b/rootfs/lib/types.rb
@@ -1,0 +1,5 @@
+require 'dry-types'
+
+module Types
+  include Dry.Types
+end

--- a/rootfs/system/boot.rb
+++ b/rootfs/system/boot.rb
@@ -1,0 +1,6 @@
+require_relative 'controller/container'
+
+Controller::Container.finalize! do |container|
+end
+
+require_relative 'controller/persistence'

--- a/rootfs/system/boot/rom.rb
+++ b/rootfs/system/boot/rom.rb
@@ -1,0 +1,23 @@
+Controller::Container.namespace 'persistence' do |persistence|
+  persistence.boot(:rom) do
+    init do
+      require 'sequel'
+      require 'rom'
+
+      Sequel.database_timezone = :utc
+      Sequel.application_timezone = :utc
+
+      rom_config = ROM::Configuration.new(
+        :sql,
+        ENV['DATABASE_URL'],
+        extensions: [:error_sql]
+      )
+
+      persistence_path = Pathname(__FILE__).join('../../../lib/persistence')
+      rom_config.auto_registration(persistence_path)
+
+      persistence.register(:rom, ROM.container(rom_config))
+    end
+
+  end
+end

--- a/rootfs/system/controller/container.rb
+++ b/rootfs/system/controller/container.rb
@@ -1,0 +1,15 @@
+require 'dry/system/container'
+
+module Controller
+  class Container < Dry::System::Container
+    configure do |config|
+      puts Pathname(__FILE__).join('../..').realpath.dirname
+      config.name = :core
+      config.root = Pathname(__FILE__).join('../..').realpath.dirname.freeze
+    end
+
+    load_paths! 'lib'
+    auto_register! 'lib'
+    #auto_register! 'lib/persistence'
+  end
+end

--- a/rootfs/system/controller/import.rb
+++ b/rootfs/system/controller/import.rb
@@ -1,0 +1,5 @@
+require_relative 'container'
+
+module Controller
+  Import = Controller::Container.injector
+end

--- a/rootfs/system/controller/persistence.rb
+++ b/rootfs/system/controller/persistence.rb
@@ -1,0 +1,3 @@
+Controller::Container.namespace 'persistence' do |container|
+
+end

--- a/rootfs/system/repository.rb
+++ b/rootfs/system/repository.rb
@@ -1,0 +1,11 @@
+require 'rom-repository'
+
+Controller::Container.start(:rom)
+
+module Controller
+  class Repository < ROM::Repository::Root
+    def self.new(rom = nil)
+      super(rom || Controller::Container['persistence.rom'])
+    end
+  end
+end


### PR DESCRIPTION
This implements the `/v2/auth/register` endpoint, which is used to create users in the cluster.

The behavior here varies very slightly from the original implementation, in so far as it tightens up the inputs via requirement and type validation.